### PR TITLE
Fix dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ First of all, you will need to configure XBMC to run in window mode
 Debian-based/Ubuntu-based
 > sudo apt-get install wmctrl
 
-RPM-based
+RHEL-based (CentOS, Fedora, ...)
 > yum install wmctrl
+
+openSUSE-based
+> zypper install wmctrl
 
 ### Setup
 


### PR DESCRIPTION
Technically speaking, `yum` is a RHEL thing, not an RPM thing :)

There's a number of other RPM-based package managers for different non-RHEL RPM distributions, like `zypper` for openSUSE and `apt-rpm` for PCLinuxOS. I believe the command for PCLinuxOS is the same as for a Debian-based distribution, but I'm not running PCLinuxOS myself and I'm not sure whether wmctrl is in the default repositories, so I haven't changed/added that.
